### PR TITLE
Update to plugin compatibility

### DIFF
--- a/activity/plugin.json
+++ b/activity/plugin.json
@@ -11,7 +11,7 @@
         "name": "Version 1.0.1",
         "date": "2020-10-12"
     },
-    "compatability": [],
+    "compatability": ["v1.0.0"],
     "installation": {
         "files": [
             "classes/ActivityPlugin.php",

--- a/hubs/plugin.json
+++ b/hubs/plugin.json
@@ -11,7 +11,7 @@
         "name": "Version 1.0.0",
         "date": "2020-10-26"
     },
-    "compatability": [],
+    "compatability": ["v1.0.0"],
     "installation": {
         "files": [
             "classes/HubsPlugin.php",

--- a/menu-items/plugin.json
+++ b/menu-items/plugin.json
@@ -11,7 +11,7 @@
         "name": "Version 1.0.0",
         "date": "2020-10-25"
     },
-    "compatability": [],
+    "compatability": ["v1.0.0"],
     "installation": {
         "files": [
             "classes/MenuPlugin.php",

--- a/notifications/plugin.json
+++ b/notifications/plugin.json
@@ -11,7 +11,7 @@
         "name": "Version 1.0.0",
         "date": "2020-10-26"
     },
-    "compatability": [],
+    "compatability": ["v1.0.0"],
     "installation": {
         "files": [
             "classes/NotifyPlugin.php",


### PR DESCRIPTION
Don’t have write access to the main repo so had to do it this way. Should fix an issue where plugins were said to be incompatible with the latest version (non-prerelease). 